### PR TITLE
issue #127 Solution

### DIFF
--- a/DSA/Python/Stacks/MergeOverlappingIntervals.cpp
+++ b/DSA/Python/Stacks/MergeOverlappingIntervals.cpp
@@ -1,0 +1,32 @@
+class Pair:
+  def __init__(self, first, second):
+    self.first = first
+    self.second = second
+
+def merge_intervals(v):
+  if v == None or len(v) == 0 :
+    return None
+
+  result = []
+  result.append(Pair(v[0].first, v[0].second))
+
+  for i in range(1, len(v)):
+    x1 = v[i].first
+    y1 = v[i].second
+    x2 = result[len(result) - 1].first
+    y2 = result[len(result) - 1].second
+
+    if y2 >= x1:
+      result[len(result) - 1].second = max(y1, y2)
+    else:
+      result.append(Pair(x1, y1))
+
+  return result;
+
+v = [Pair(1, 5), Pair(3, 1), Pair(4, 6), Pair(6, 9), 
+     Pair(10, 12), Pair(11, 20)]
+
+result = merge_intervals(v)
+
+for i in range(len(result)):
+  print("[" + str(result[i].first) + ", " + str(result[i].second) + "]", end =" ")

--- a/DSA/Python/Stacks/MergeOverlappingIntervals.py
+++ b/DSA/Python/Stacks/MergeOverlappingIntervals.py
@@ -1,0 +1,32 @@
+class Pair:
+  def __init__(self, first, second):
+    self.first = first
+    self.second = second
+
+def merge_intervals(v):
+  if v == None or len(v) == 0 :
+    return None
+
+  result = []
+  result.append(Pair(v[0].first, v[0].second))
+
+  for i in range(1, len(v)):
+    x1 = v[i].first
+    y1 = v[i].second
+    x2 = result[len(result) - 1].first
+    y2 = result[len(result) - 1].second
+
+    if y2 >= x1:
+      result[len(result) - 1].second = max(y1, y2)
+    else:
+      result.append(Pair(x1, y1))
+
+  return result;
+
+v = [Pair(1, 5), Pair(3, 1), Pair(4, 6), Pair(6, 9), 
+     Pair(10, 12), Pair(11, 20)]
+
+result = merge_intervals(v)
+
+for i in range(len(result)):
+  print("[" + str(result[i].first) + ", " + str(result[i].second) + "]", end =" ")


### PR DESCRIPTION
# Problem Statement
[Leet Code Problem] (https://leetcode.com/problems/merge-intervals)

Given an array (list) of interval pairs as input where each interval has a start and end timestamp. The input array is sorted by starting timestamps. Merge overlapping intervals and return a new output array.

Overlapping Intervals (1, 5), (3, 7), (4, 6), (6, 9)
Merged to one big interval as (1, 9).

# Solution
This problem can be solved in a simple linear Scan algorithm. We know that input is sorted by starting timestamps.
Approach are following:
List of input intervals is given, keep merged intervals in the output list.
For each interval in the input list:
If the input interval is overlapping with the last interval in output list then we’ll merge these two intervals and update the last interval of output list with merged interval.
Otherwise, we’ll add an input interval to the output list.

The runtime complexity of this solution is linear, O(n).
The memory complexity of this solution is linear, O(n).